### PR TITLE
Add support for missing GATT constants and delay trait

### DIFF
--- a/src/command/gatt.rs
+++ b/src/command/gatt.rs
@@ -1549,6 +1549,9 @@ bitflags! {
     /// [Permissions](AddCharacteristicParameter::security_permissions) available for
     /// characteristics.
     pub struct CharacteristicPermission: u8 {
+        /// No security.
+        const NONE = 0x00;
+
         /// Need authentication to read.
         const AUTHENTICATED_READ = 0x01;
 
@@ -1572,6 +1575,9 @@ bitflags! {
 bitflags! {
     /// Which events may be generated when a characteristic is accessed.
     pub struct CharacteristicEvent: u8 {
+        /// No events.
+        const NONE = 0x00;
+
         /// The application will be notified when a client writes to this attribute.
         const ATTRIBUTE_WRITE = 0x01;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate embedded_hal as emhal;
 extern crate nb;
 
 use byteorder::{ByteOrder, LittleEndian};
+use emhal::blocking;
 use core::cmp::min;
 use core::convert::TryFrom;
 use core::marker::PhantomData;
@@ -489,6 +490,22 @@ where
         self.reset.set_high().map_err(nb::Error::Other)?;
         timer.start(freq);
         block!(timer.wait()).unwrap();
+
+        Ok(())
+    }
+
+    /// Resets the BlueNRG Controller. Uses the given delay to wait
+    /// `time` milliseconds after toggling the reset pin.
+    pub fn reset_with_delay<D, UXX>(&mut self, delay: &mut D, time: UXX) -> nb::Result<(), OutputPin2::Error>
+    where
+        D: blocking::delay::DelayMs<UXX>,
+        UXX: Copy,
+    {
+        self.reset.set_low().map_err(nb::Error::Other)?;
+        delay.delay_ms(time);
+
+        self.reset.set_high().map_err(nb::Error::Other)?;
+        delay.delay_ms(time);
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds the following:

1. Missing GATT constant:  `CharacteristPermission::NONE` 
2. Missing GATT constant: `CharacteristicEvent::NONE`
3. A new controller reset method to support devices that do not implement the `embedded_hal::timer::CountDown` trait: `reset_with_delay`