### PR TITLE
Support mutable ref to data ready pin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,6 +514,11 @@ where
     fn data_ready(&self) -> Result<bool, InputPin::Error> {
         self.data_ready.is_high()
     }
+
+    /// Mutable reference to the data ready pin
+    pub fn data_ready_pin_mut(&mut self) -> &mut InputPin {
+        &mut self.data_ready
+    }
 }
 
 /// Vendor-specific interpretation of the local version information from the controller.


### PR DESCRIPTION
Hey there, thanks for a super lib. 

I'm using [rtic](https://github.com/rtic-rs/cortex-m-rtic), and need access to `clear_interrupt_pending_bit` of the data ready pin to handle an interrupt and deal with the event. This adds a simple method `BlueNRG::data_ready_pin_mut` to gain access to that pin.

Let me know if I should add or refactor anything, I know this lib is in a minimally maintained state. 